### PR TITLE
Force the named container to always be the leader

### DIFF
--- a/test/causal-cluster-compose.yml
+++ b/test/causal-cluster-compose.yml
@@ -31,6 +31,7 @@ services:
       - NEO4J_dbms_mode=CORE
       - NEO4J_causalClustering_expectedCoreClusterSize=3
       - NEO4J_causalClustering_initialDiscoveryMembers=core1:5000,core2:5000,core3:5000
+      - NEO4J_causalClustering_refuseToBeLeader=true
 
   core3:
     image: neo4j:3.1-enterprise
@@ -47,6 +48,7 @@ services:
       - NEO4J_causalClustering_raftAdvertisedAddress=core3:7000
       - NEO4J_causalClustering_expectedCoreClusterSize=3
       - NEO4J_causalClustering_initialDiscoveryMembers=core1:5000,core2:5000,core3:5000
+      - NEO4J_causalClustering_refuseToBeLeader=true
 
   readreplica1:
     image: neo4j:3.1-enterprise

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -130,7 +130,7 @@ neo4j_wait() {
 
   while true; do
     [[ "200" = "$("${EXEC[@]}" "${CURL[@]}" ${auth:-} http://${l_ip}:7474)" ]] && break
-    [[ "${SECONDS}" -ge "${end}" ]] && exit 1
+    [[ "${SECONDS}" -ge "${end}" ]] && echo "timed out waiting for neo4j" && exit 1
     sleep 1
   done
 }

--- a/test/test-dumps-config
+++ b/test/test-dumps-config
@@ -12,6 +12,7 @@ readonly dir=$(mktemp --directory)
 GID="$(gid_of "${dir}")"
 readonly GID
 
+echo "dumping config to ${dir}"
 docker run --rm --volume="${dir}:/conf" --user="$(id -u):$(id -g)" "${image}" dump-config
 
 if [[ "${series}" == "2.3" ]]; then

--- a/test/test-ignore-numeric-vars
+++ b/test/test-ignore-numeric-vars
@@ -11,9 +11,10 @@ readonly cname="neo4j-$(uuidgen)"
 
 docker_run "$image" "$cname" "NEO4J_1a=1 NEO4J_AUTH=none"
 readonly ip="$(docker_ip "${cname}")"
+echo "waiting for neo4j"
 neo4j_wait "${ip}"
 
-stderr="$((docker logs "${cname}" 1>/dev/null) 2>&1)"
+stderr="$( (docker logs "${cname}" 1>/dev/null) 2>&1 )"
 
 if [[ "${series}" == "2.3" ]]; then
   expected_err=""

--- a/test/test-neo4j-admin-conf-override
+++ b/test/test-neo4j-admin-conf-override
@@ -19,7 +19,6 @@ if [[ "${series}" == "2.3" ]]; then
 fi
 
 . "$(dirname "$0")/helpers.sh"
-readonly cname="neo4j-$(uuidgen)"
 
 readonly dir=$(mktemp --directory)
 touch "${dir}/neo4j.conf"


### PR DESCRIPTION
This forces the named container to be the leader in the test cluster setup. The other two cores refuse to be leader. This should reduce noise in TC and make testing simpler. 

Obviously we should also test using `bolt+routing`! But that's more work and in the meantime I think this is an improvement.

Also some additional logging and tidying up.